### PR TITLE
Fix table scroll on mobile

### DIFF
--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -1,0 +1,27 @@
+// This needs to be an odd number, to prevent some slightly thicker line on
+// horizontal scroll (https://github.com/gbdev/rgbds-www/pull/26#issuecomment-989158940)
+$navbar-height: 51px;
+$navbar-border-bottom: 1px;
+$navbar-box-height: $navbar-height + $navbar-border-bottom;
+$navbar-breakpoint: 720px; // Width at which the navbar collapses
+$navbar-bg-color: #e2e8cb;
+
+$logo-padding-top:        10px;
+$logo-padding-bottom:     10px;
+$logo-padding-left:       20px;
+$logo-padding-right:       0px;
+
+$nav-link-padding-top:     7px;
+$nav-link-padding-bottom: 14px;
+$nav-link-padding-left:   10px;
+$nav-link-padding-right:  10px;
+$nav-logo-padding-top:     5px;
+$nav-logo-padding-bottom:  5px;
+
+$max-width: 50em;
+
+/// media-queries
+$mobile-device: 480px;
+
+/// colors
+$main-background: #eee;

--- a/css/default.scss
+++ b/css/default.scss
@@ -2,28 +2,7 @@
 ---
 
 @import "monokai";
-
-/// Variable definitions
-
-$navbar-height: 51px;
-$navbar-border-bottom: 1px;
-$navbar-box-height: $navbar-height + $navbar-border-bottom;
-$navbar-breakpoint: 720px; // Width at which the navbar collapses
-$navbar-bg-color: #e2e8cb;
-
-$logo-padding-top:        10px;
-$logo-padding-bottom:     10px;
-$logo-padding-left:       20px;
-$logo-padding-right:       0px;
-
-$nav-link-padding-top:     7px;
-$nav-link-padding-bottom: 14px;
-$nav-link-padding-left:   10px;
-$nav-link-padding-right:  10px;
-$nav-logo-padding-top:     5px;
-$nav-logo-padding-bottom:  5px;
-
-$max-width: 50em;
+@import "variables";
 
 /// General styling
 
@@ -43,6 +22,11 @@ body {
 
 	margin: 0;
 	width: 100%;
+
+@media screen and (max-width: $mobile-device) {
+		// prevent background image leak
+		background: $main-background;
+	}
 }
 
 code, pre {
@@ -200,5 +184,5 @@ main {
 	max-width: $max-width;
 	// Prevent text from bumping sides on smaller windows
 	padding: 10px 20px;
-	background: #eee;
+	background: $main-background;
 }

--- a/css/default.scss
+++ b/css/default.scss
@@ -5,7 +5,7 @@
 
 /// Variable definitions
 
-$navbar-height: 50px;
+$navbar-height: 51px;
 $navbar-border-bottom: 1px;
 $navbar-box-height: $navbar-height + $navbar-border-bottom;
 $navbar-breakpoint: 720px; // Width at which the navbar collapses
@@ -88,7 +88,6 @@ body {
 
 	background-color: $navbar-bg-color;
 	border-bottom: 1px solid #ccc;
-	box-shadow: 0 0 20px rgba(204,204,204,0.5);
 }
 
 #logo {

--- a/css/doc.scss
+++ b/css/doc.scss
@@ -16,6 +16,18 @@ permalink: /css/doc.css
 #man table.Bl-column {
 	border-collapse: collapse;
 
+	@media screen and (max-width: 480px) {
+		// This is to utilize all available space better on mobile
+		margin-left: 0;
+
+		td, th {
+			// break basically everything if space is small
+			word-break: break-word;
+			// Force min-width in conjunction with word-break setting
+			min-width: 15vw;
+		}
+	}
+
 	tr:not(:first-child) {
 		> td, > th {
 			border-top: 1px solid #aaa;

--- a/css/doc.scss
+++ b/css/doc.scss
@@ -16,18 +16,6 @@ permalink: /css/doc.css
 #man table.Bl-column {
 	border-collapse: collapse;
 
-	@media screen and (max-width: 480px) {
-		// This is to utilize all available space better on mobile
-		margin-left: 0;
-
-		td, th {
-			// break basically everything if space is small
-			word-break: break-word;
-			// Force min-width in conjunction with word-break setting
-			min-width: 15vw;
-		}
-	}
-
 	tr:not(:first-child) {
 		> td, > th {
 			border-top: 1px solid #aaa;
@@ -42,5 +30,21 @@ permalink: /css/doc.css
 	td, th {
 		// Add horizontal spacing between columns
 		padding: 2px 7px 0;
+	}
+}
+
+@media screen and (max-width: 480px) {
+	#man {
+		table.Bl-column {
+			// This is to utilize all available space better on mobile
+			margin-left: 0;
+
+			td, th {
+				// break basically everything if space is small
+				word-break: break-word;
+				// Force min-width in conjunction with word-break setting
+				min-width: 15vw;
+			}
+		}
 	}
 }

--- a/css/doc.scss
+++ b/css/doc.scss
@@ -34,14 +34,20 @@ permalink: /css/doc.css
 }
 
 @media screen and (max-width: 480px) {
+	body {
+		// prevent background leak
+		background: #eee;
+	}
 	#man {
 		table.Bl-column {
 			// This is to utilize all available space better on mobile
 			margin-left: 0;
+			table-layout: fixed;
+			max-width: 200vw;
 
 			td, th {
 				// break basically everything if space is small
-				word-break: break-word;
+				overflow-wrap: break-word;
 				// Force min-width in conjunction with word-break setting
 				min-width: 15vw;
 			}

--- a/css/doc.scss
+++ b/css/doc.scss
@@ -3,6 +3,8 @@ layout: null
 permalink: /css/doc.css
 ---
 
+@import "variables";
+
 #man {
 	// Disable justification (see https://github.com/gbdev/rgbds-www/issues/13)
 	text-align: left;
@@ -33,11 +35,7 @@ permalink: /css/doc.css
 	}
 }
 
-@media screen and (max-width: 480px) {
-	body {
-		// prevent background leak
-		background: #eee;
-	}
+@media screen and (max-width: $mobile-device) {
 	#man {
 		table.Bl-column {
 			// This is to utilize all available space better on mobile


### PR DESCRIPTION
Hey there,

i'm using the RGBDS docs quite often, saw the list of issues and thought i might have a go on some of those.

This pull request addresses issue https://github.com/gbdev/rgbds-www/issues/10 regarding the tables overflowing and causing scrolling which messes with the general layout.

I chose to conditionally remove the indentation of the tables on mobile devices (<480px) and use `word-break: break-word` in order to get the table fitted within the available screen space. In order to have sane column widths, i set those to have a minimum of 15vw.

I checked all pages and think this might be a solution to the problem stated.

![211202-table-overflow](https://user-images.githubusercontent.com/11561719/144506015-e377b383-2943-469d-b2e9-3774ac8513b3.gif)
