### PR TITLE
Fix broken escape sequences on FAQ and install pages

### DIFF
--- a/src/pages/faq.md
+++ b/src/pages/faq.md
@@ -6,7 +6,7 @@ This error occurs when RGBLINK is unable to place a `SECTION`. There are several
 
 This is almost always caused by some modification growing a section too large, **although not necessarily the one being reported**. To understand why, imagine several groups renting a bus, where members of the same group all try to board together; if the bus became overfull, the problem is shared, not the fault of the last group that tried to board.
 
-The error message is of the form `Unable to place "\<section\>" <where>: <reason>`. `\<section\>` is the section's name. `<where>` is RGBLINK telling which constraints were put on the section, which is one of, or a combination of the following. (Note that the list is ordered from most to least restrictive, and that combinations are more restrictive than either of their components.)
+The error message is of the form `Unable to place "<section>" <where>: <reason>`. `<section>` is the section's name. `<where>` is RGBLINK telling which constraints were put on the section, which is one of, or a combination of the following. (Note that the list is ordered from most to least restrictive, and that combinations are more restrictive than either of their components.)
 
  - **in bank &lt;bank&gt;**: The section was restricted to a certain bank.
  - **at address &lt;addr&gt;**: The section was restricted to a certain address.

--- a/src/pages/install.md
+++ b/src/pages/install.md
@@ -70,7 +70,7 @@ However, if you have such an environment, we recommend you follow its specific i
 3. Unzip that file, you should get the `.exe` files alongside a couple of `.dll`s.
 4. Either:
    - Put all of the files in a directory, then add it to the `PATH`.
-     This will permanently allow you to use RGBDS. If you only want to modify the PATH temporarily, instead of the permanent [`setx` command](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/setx), you can use  the **temporary** [`set` one](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/set_1): `set PATH="%PATH%&lt;rgbds_path&gt;` for `cmd.exe`.
+     This will permanently allow you to use RGBDS. If you only want to modify the PATH temporarily, instead of the permanent [`setx` command](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/setx), you can use  the **temporary** [`set` one](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/set_1): <code>set PATH="%PATH%<var>&lt;rgbds_path&gt;</var></code> for `cmd.exe`.
      Use one of the following methods:
      - Graphically:
        1. Open Control Panel
@@ -84,9 +84,9 @@ However, if you have such an environment, we recommend you follow its specific i
        9. Click "OK"
        10. Click "OK"
      - Using a command line:
-       1. Use Explorer to go into the folder the files are in (you should see `rgbasm.exe` etc.), and click a blank part of the address bar near the top. Copy this path, and **use this instead of `&lt;rgbds_path&gt;` in the third step!**
+       1. Use Explorer to go into the folder the files are in (you should see `rgbasm.exe` etc.), and click a blank part of the address bar near the top. Copy this path, and **use this instead of <code><var>&lt;rgbds_path&gt;</var></code> in the third step!**
        2. Open `cmd` or PowerShell
-       3. Type `setx PATH "%PATH%&lt;rgbds_path&gt;;"` for `cmd.exe`, or `setx PATH ${"{"}Env:PATH}&lt;rgbds_path&gt;;` for PowerShell; replace `&lt;rgbds_path&gt;` with the path you copied in the first step
+       3. Type <code>setx PATH "%PATH%<var>&lt;rgbds_path&gt;</var>;"</code> for `cmd.exe`, or <code>setx PATH ${"{"}Env:PATH}<var>&lt;rgbds_path&gt;</var>;</code> for PowerShell; replace <code><var>&lt;rgbds_path&gt;</var></code> with the path you copied in the first step
        4. Close the window for the changes to take effect
    - Put all of the files in your project's directory
    - Put all of the files in a directory already in the `PATH`


### PR DESCRIPTION
For the most part, text surrounded by backticks is automatically escaped, so the backslashes or HTML escapes were showing up on the page, which is confusing. For the FAQ page, I've removed the backslashes. For the install page, I've used the [`<var>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var) which is more semantically correct (and results in italic formatting); that's not directly exposed in markdown, so I had to use code tags instead of backticks.

I haven't tested this beyond confirming that the pages now appear correctly on GitHub.

Here's what the pages looked like before this fix:

![image](https://user-images.githubusercontent.com/8334194/173247649-445c32ab-7b38-4a2d-81c5-db7a1d6039cb.png)
![image](https://user-images.githubusercontent.com/8334194/173247662-99db93e5-0057-42e6-933b-ba608abcedc4.png)
