### PR TITLE
Specify correct single-user prefix when installing from source

### DIFF
--- a/src/pages/install.md
+++ b/src/pages/install.md
@@ -177,7 +177,7 @@ sudo make install
 
 The second command is optional if you don't want to install RGBDS system-wide.
 
-The following variables can be defined to control installation, like so: `make Q=`, `sudo make install PREFIX=~/.local/bin`
+The following variables can be defined to control installation, like so: `make Q=`, `make install PREFIX=~/.local`
 
  - `PREFIX`: Location where RGBDS will be installed. Defaults to `/usr/local`.
  - `bindir`: Location where the binaries will be installed. Defaults to `${PREFIX}/bin`.


### PR DESCRIPTION
The build instructions specify the following command:

```
sudo make install PREFIX=~/.local/bin
```

I think the command should be:

```
make install PREFIX=~/.local
```

That is:
* not as root
* without the extraneous `/bin`. (Otherwise you end up with binaries installed on a path like `~/.local/bin/bin/rgblink`, and manpages installed in `~/.local/bin/share/man...`)