### PR TITLE
Fix SRL [HL] Flags link

### DIFF
--- a/docs/gbz80.7.html
+++ b/docs/gbz80.7.html
@@ -1559,7 +1559,7 @@ ld [sp], LOW(r16) ; C, E or L</pre>
 <div class="Bd Bd-indent">0 -&gt; [7 -&gt; 0] -&gt; C</div>
 <p class="Pp">Cycles: 4</p>
 <p class="Pp">Bytes: 2</p>
-<p class="Pp">Flags: See <a class="Sx" href="#SRA_r8">SRA r8</a></p>
+<p class="Pp">Flags: See <a class="Sx" href="#SRL_r8">SRL r8</a></p>
 </section>
 <section class="Ss">
 <h3 class="Ss" id="STOP"><a class="permalink" href="#STOP">STOP</a></h3>


### PR DESCRIPTION
It should point to `SRL r8` instead of `SRA r8`