### PR TITLE
Overhaul "Install" instructions

### DIFF
--- a/src/pages/install/index.md
+++ b/src/pages/install/index.md
@@ -14,7 +14,7 @@ Below is a list of Operative Systems for which pre-built executables are availab
 
 Linux x86_64 ready binaries are available in our [Releases](https://github.com/gbdev/rgbds/releases) page.
 
-##### Arch
+### Arch
 
 RGBDS is available in the official Arch Linux repositories as [`community/rgbds`](https://www.archlinux.org/packages/community/x86_64/rgbds/); you can also get the [latest master](/docs/master) via the [`rgbds-git`](https://aur.archlinux.org/packages/rgbds-git) AUR package.
 
@@ -22,6 +22,9 @@ RGBDS is available in the official Arch Linux repositories as [`community/rgbds`
 pacman -S rgbds
 ```
 
+### Others
+
+If your distribution is not listed above, you must [build from source](./source.md).
 
 </TabItem>
 
@@ -45,17 +48,42 @@ brew install rgbds --HEAD
 
 The install instructions change a bit depending on the environment you wish to use RGBDS with.
 
-<details>
-<summary>"Plain" Windows (CMD, PowerShell)</summary>
+<Tabs>
+<TabItem value="wsl" label="WSL / Linux-like environments">
 
-1. First, [pick the version you want to install](/docs). If you want to [use `master`](/docs/master/#what) instead of a release, [go here](#using-rgbds-master).
+For these, please refer to the Linux instructions for the installed Linux distribution.
+(The default Linux distribution on WSL is Ubuntu, whose package manager is `apt`.)
+
+</TabItem>
+<TabItem value="cygwin" label="Cygwin / MSYS2">
+
+1. First, [pick the version you want to install](/docs). If you want to [use `master`](/docs/master/#what) instead of a release, [go here](/install/master).
+2. Follow the "release page" link below "GitHub links", and grab either of the `win32` (for 32-bit Windows) or `win64` (for 64-bit Windows) `.zip` files, near the bottom of the page.
+3. Unzip that file, you should get the `.exe` files alongside a couple of `.dll`s.
+4. Copy all of those `.exe` and `.dll` files to the `/usr/local/bin` directory of Cygwin/MSYS2's installation.
+   (You can get its equivalent Windows path by running `cygpath -w /usr/local/bin`.)
+
+   **Do not put them in a subdirectory** (e.g. `/usr/local/bin/rgbds`)**!**
+   This would not work.
+
+After that, you should be able to use RGBDS from within the Cygwin/MSYS2 terminal, which you can confirm by running `rgbasm -V`.
+If this doesn't work, check that `/usr/local/bin` is within the PATH there (`echo $PATH`); if it isn't, you must add it (e.g. run `echo 'export PATH="/usr/local/bin:$PATH"' >>~/.bashrc`, and open a new Cygwin terminal).
+
+Note: if you can choose between using Cygwin or MSYS2, be advised that Cygwin is slower and has been reported to cause a bit of trouble to some.
+
+</TabItem>
+<TabItem value="win32" label="None of those">
+
+1. First, [pick the version you want to install](/docs). If you want to [use `master`](/docs/master/#what) instead of a release, [go here](/install/master).
 2. Follow the "release page" link below "GitHub links", and grab either of the `win32` (for 32-bit Windows) or `win64` (for 64-bit Windows) `.zip` files, near the bottom of the page.
 3. Unzip that file, you should get the `.exe` files alongside a couple of `.dll`s.
 4. Either:
-   - Put all of the files in a directory, then add it to the `PATH`.
-     This will permanently allow you to use RGBDS. If you only want to modify the PATH temporarily, instead of the permanent [`setx` command](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/setx), you can use  the **temporary** [`set` one](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/set_1): <code>set PATH="%PATH%<var>&lt;rgbds_path&gt;</var></code> for `cmd.exe`.
-     Use one of the following methods:
-     - Graphically:
+   - ...put all of the files in a directory, then add it to the `PATH`.
+     This will **permanently** allow you to use RGBDS **from anywhere**.
+
+     <Tabs>
+     <TabItem value="gui" label="Graphically">
+
        1. Open Control Panel
        2. Click "User Accounts"
        3. Click "User Accounts" again
@@ -66,37 +94,42 @@ The install instructions change a bit depending on the environment you wish to u
        8. Make sure that the new entry (which should be highlighted) is at the bottom of the list; if not, click on "Move Down" until it is
        9. Click "OK"
        10. Click "OK"
-     - Using a command line:
-       1. Use Explorer to go into the folder the files are in (you should see `rgbasm.exe` etc.), and click a blank part of the address bar near the top. Copy this path, and **use this instead of <code><var>&lt;rgbds_path&gt;</var></code> in the third step!**
-       2. Open `cmd` or PowerShell
-       3. Type <code>setx PATH "%PATH%<var>&lt;rgbds_path&gt;</var>;"</code> for `cmd.exe`, or <code>setx PATH ${"{"}Env:PATH}<var>&lt;rgbds_path&gt;</var>;</code> for PowerShell; replace <code><var>&lt;rgbds_path&gt;</var></code> with the path you copied in the first step
-       4. Close the window for the changes to take effect
-   - Put all of the files in your project's directory
-   - Put all of the files in a directory already in the `PATH`
+
+     </TabItem>
+     <TabItem value="cmd.exe" label="cmd.exe">
+
+       Run the following, replacing `<rgbds_path>` with the path to the directory that contains `rgbasm.exe`, `rgblink.exe`, etc.
+
+       ```cmd
+       setx PATH "%PATH%<rgbds_path>;"
+       ```
+
+       ...then open a new window for the changes to take effect.
+
+       If you only want to modify the PATH temporarily, instead of the permanent [`setx` command](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/setx), you can use  the **temporary** [`set`](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/set_1).
+
+     </TabItem>
+     <TabItem value="pwsh" label="PowerShell">
+
+       Run the following, replacing `<rgbds_path>` with the path to the directory that contains `rgbasm.exe`, `rgblink.exe`, etc.
+
+       ```cmd
+       setx PATH ${Env:PATH}<rgbds_path>;
+       ```
+
+       ...then open a new window for the changes to take effect.
+
+       If you only want to modify the PATH temporarily, instead of the permanent [`setx` command](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/setx), you can use  the **temporary** [`set`](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/set_1).
+
+     </TabItem>
+     </Tabs>
+
+   - ...or put all of the files in your project's directory.
+   - ...or put all of the files in a directory already in the `PATH`.
 5. Profit! RGBDS can now be used from your favorite command line (`cmd.exe` or PowerShell, most likely). You can test it by running `rgbasm --version`.
 
-</details>
-<details>
-<summary>Cygwin, MSYS2</summary>
-
-Follow steps 1 to 3 of the "plain Windows" instructions to get the release's files; then, copy all of the `.exe` and `.dll` files to the `/usr/local/bin` directory of Cygwin/MSYS2's installation.
-(You can get its equivalent Windows path by running `cygpath -w /usr/local/bin`.)
-**Do not put them in a subdirectory** (e.g. `/usr/local/bin/rgbds`)**!**
-This would not work.
-
-After that, you should be able to use RGBDS from within the Cygwin/MSYS2 terminal, which you can confirm by running `rgbasm -V`.
-If this doesn't work, check that `/usr/local/bin` is within the PATH there (`echo $PATH`); if it isn't, you must add it (e.g. `export PATH="/usr/local/bin:$PATH"` in the `~/.bashrc`).
-
-Note: if you can choose between using Cygwin or MSYS2, be advised that Cygwin is slower and has been reported to cause a bit of trouble to some.
-
-</details>
-<details>
-<summary>WSL, and all other Linux-like environments</summary>
-
-For these, you have to [build from source](/install/source).
-On WSL, the default package manager (to install any build prerequisites) is `apt-get` (example: `sudo apt-get install libpng-dev`).
-
-</details>
+</TabItem>
+</Tabs>
 
 </TabItem>
 
@@ -111,12 +144,10 @@ docker pull ghcr.io/gbdev/rgbds:latest
 </TabItem>
 </Tabs>
 
-<br />
-
-### Installing a development version
+## Installing a development version
 
 If you are willing to help us test new features, consider [using a development version](/install/master).
 
-### Managing multiple versions
+## Managing multiple versions
 
 If you need to frequently switch between different versions of RGBDS, consider using [rgbenv](https://github.com/gbdev/rgbenv), the RGBDS version manager.

--- a/src/pages/install/index.md
+++ b/src/pages/install/index.md
@@ -12,7 +12,14 @@ Below is a list of <abbr title="Operating System">OS</abbr>es for which we know 
 If your OS isn’t listed below, try finding `rgbds` in your package manager—refer to your OS' documentation for help.
 If you still can’t find RGBDS, or the specific version you are looking for is unavailable, you will have to [compile it from source](#building-from-source).
 
+
 <Tabs>
+<TabItem value="linux" label="Linux">
+
+TO DO
+
+</TabItem>
+
 <TabItem value="windows" label="Windows">
 
 The install instructions change a bit depending on the environment you wish to use RGBDS with.
@@ -73,7 +80,7 @@ On WSL, the default package manager (to install any build prerequisites) is `apt
 </TabItem>
 <TabItem value="arch" label="Arch Linux">
 
-RGBDS is now available in the official repos as [`community/rgbds`](https://www.archlinux.org/packages/community/x86_64/rgbds/); you can also get the [latest master](/docs/master) via the [`rgbds-git`](https://aur.archlinux.org/packages/rgbds-git) AUR package, or RGBDS 0.2.5 from [`rgbds2`](https://aur.archlinux.org/packages/rgbds2), still from the AUR.
+RGBDS is now available in the official repos as [`community/rgbds`](https://www.archlinux.org/packages/community/x86_64/rgbds/); you can also get the [latest master](/docs/master) via the [`rgbds-git`](https://aur.archlinux.org/packages/rgbds-git) AUR package.
 
 ```bash
 pacman -S rgbds

--- a/src/pages/install/index.md
+++ b/src/pages/install/index.md
@@ -9,12 +9,11 @@ Most people will want to use a stable release (the more recent the better).
 Below is a list of Operative Systems for which pre-built executables are available. If none of these options fits your needs, you can [build from source](/install/source).
 
 
-<Tabs>
-<TabItem value="linux" label="Linux">
+## Linux
 
-Linux x86_64 ready binaries are available in our [Releases](https://github.com/gbdev/rgbds/releases) page.
+Generic Linux x86_64 ready binaries are available in our [Releases](https://github.com/gbdev/rgbds/releases) page.
 
-### Arch
+##### Arch
 
 RGBDS is available in the official Arch Linux repositories as [`community/rgbds`](https://www.archlinux.org/packages/community/x86_64/rgbds/); you can also get the [latest master](/docs/master) via the [`rgbds-git`](https://aur.archlinux.org/packages/rgbds-git) AUR package.
 
@@ -22,13 +21,8 @@ RGBDS is available in the official Arch Linux repositories as [`community/rgbds`
 pacman -S rgbds
 ```
 
-### Others
 
-If your distribution is not listed above, you must [build from source](./source.md).
-
-</TabItem>
-
-<TabItem value="macos" label="macOS">
+## macOS
 
 RGBDS is available on [Homebrew](https://brew.sh) as the [`rgbds` package](https://formulae.brew.sh/formula/rgbds).
 
@@ -42,17 +36,14 @@ You can also install the [`master` branch](/docs/master) by passing the `--HEAD`
 brew install rgbds --HEAD
 ```
 
-</TabItem>
-
-<TabItem value="windows" label="Windows">
+## Windows
 
 The install instructions change a bit depending on the environment you wish to use RGBDS with.
 
 <Tabs>
 <TabItem value="wsl" label="WSL / Linux-like environments">
 
-For these, please refer to the Linux instructions for the installed Linux distribution.
-(The default Linux distribution on WSL is Ubuntu, whose package manager is `apt`.)
+For these, please refer to the Linux instructions for the installed Linux distribution (the default Linux distribution on WSL is Ubuntu, whose package manager is `apt`).
 
 </TabItem>
 <TabItem value="cygwin" label="Cygwin / MSYS2">
@@ -131,9 +122,9 @@ Note: if you can choose between using Cygwin or MSYS2, be advised that Cygwin is
 </TabItem>
 </Tabs>
 
-</TabItem>
+## Other
 
-<TabItem value="docker" label="Docker">
+### Docker
 
 We distribute an [official container image for RGBDS](https://github.com/gbdev/rgbds/pkgs/container/rgbds). It contains the built executables and the build dependencies in case you want to compile from source.
 
@@ -141,13 +132,10 @@ We distribute an [official container image for RGBDS](https://github.com/gbdev/r
 docker pull ghcr.io/gbdev/rgbds:latest
 ```
 
-</TabItem>
-</Tabs>
-
-## Installing a development version
+### Installing a development version
 
 If you are willing to help us test new features, consider [using a development version](/install/master).
 
-## Managing multiple versions
+### Managing multiple versions
 
 If you need to frequently switch between different versions of RGBDS, consider using [rgbenv](https://github.com/gbdev/rgbenv), the RGBDS version manager.

--- a/src/pages/install/index.md
+++ b/src/pages/install/index.md
@@ -4,19 +4,40 @@ import TabItem from '@theme/TabItem';
 
 # Installing RGBDS
 
-Most people will want to use a release (the more recent the better), but if you are willing to help us test new features, you may consider [using a development version](/install/master).
+Most people will want to use a stable release (the more recent the better). 
 
-The two main options to install a release of RGBDS are to download pre-built executables, or to [build from source](/install/source).
-Below is a list of <abbr title="Operating System">OS</abbr>es for which we know pre-built executables are available.
-
-If your OS isn’t listed below, try finding `rgbds` in your package manager—refer to your OS' documentation for help.
-If you still can’t find RGBDS, or the specific version you are looking for is unavailable, you will have to [compile it from source](#building-from-source).
+Below is a list of Operative Systems for which pre-built executables are available. If none of these options fits your needs, you can [build from source](/install/source).
 
 
 <Tabs>
 <TabItem value="linux" label="Linux">
 
-TO DO
+Linux x86_64 ready binaries are available in our [Releases](https://github.com/gbdev/rgbds/releases) page.
+
+##### Arch
+
+RGBDS is available in the official Arch Linux repositories as [`community/rgbds`](https://www.archlinux.org/packages/community/x86_64/rgbds/); you can also get the [latest master](/docs/master) via the [`rgbds-git`](https://aur.archlinux.org/packages/rgbds-git) AUR package.
+
+```bash
+pacman -S rgbds
+```
+
+
+</TabItem>
+
+<TabItem value="macos" label="macOS">
+
+RGBDS is available on [Homebrew](https://brew.sh) as the [`rgbds` package](https://formulae.brew.sh/formula/rgbds).
+
+```bash
+brew install rgbds
+```
+
+You can also install the [`master` branch](/docs/master) by passing the `--HEAD` flag:
+
+```bash
+brew install rgbds --HEAD
+```
 
 </TabItem>
 
@@ -78,30 +99,24 @@ On WSL, the default package manager (to install any build prerequisites) is `apt
 </details>
 
 </TabItem>
-<TabItem value="arch" label="Arch Linux">
 
-RGBDS is now available in the official repos as [`community/rgbds`](https://www.archlinux.org/packages/community/x86_64/rgbds/); you can also get the [latest master](/docs/master) via the [`rgbds-git`](https://aur.archlinux.org/packages/rgbds-git) AUR package.
+<TabItem value="docker" label="Docker">
 
-```bash
-pacman -S rgbds
-```
-
-We refer you to the Arch Linux wiki on how to install [official packages](https://wiki.archlinux.org/index.php/Pacman#Installing_packages) or [AUR packages](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_and_upgrading_packages), or to find and use an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers).
-
-</TabItem>
-<TabItem value="macos" label="macOS">
-
-RGBDS is available on [Homebrew](https://brew.sh) as the [`rgbds` package](https://formulae.brew.sh/formula/rgbds).
+We distribute an [official container image for RGBDS](https://github.com/gbdev/rgbds/pkgs/container/rgbds). It contains the built executables and the build dependencies in case you want to compile from source.
 
 ```bash
-brew install rgbds
-```
-
-You can also install the [`master` branch](/docs/master) by passing the `--HEAD` flag:
-
-```bash
-brew install rgbds --HEAD
+docker pull ghcr.io/gbdev/rgbds:latest
 ```
 
 </TabItem>
 </Tabs>
+
+<br />
+
+### Installing a development version
+
+If you are willing to help us test new features, consider [using a development version](/install/master).
+
+### Managing multiple versions
+
+If you need to frequently switch between different versions of RGBDS, consider using [rgbenv](https://github.com/gbdev/rgbenv), the RGBDS version manager.

--- a/src/pages/install/index.md
+++ b/src/pages/install/index.md
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # Installing RGBDS
 
-Most people will want to use a release (the latest the bestest!), but if you are willing to help us test new features, you may consider [using a development version](/install/master).
+Most people will want to use a release (the more recent the better), but if you are willing to help us test new features, you may consider [using a development version](/install/master).
 
 The two main options to install a release of RGBDS are to download pre-built executables, or to [build from source](/install/source).
 Below is a list of <abbr title="Operating System">OS</abbr>es for which we know pre-built executables are available.
@@ -16,13 +16,6 @@ If you still can’t find RGBDS, or the specific version you are looking for is 
 <TabItem value="windows" label="Windows">
 
 The install instructions change a bit depending on the environment you wish to use RGBDS with.
-
-:::tip
-
-The "plain Windows" instructions may also work for some environments listed further below, since most of them pick up Windows' `PATH`.
-However, if you have such an environment, we recommend you follow its specific install instructions instead.
-
-:::
 
 <details>
 <summary>"Plain" Windows (CMD, PowerShell)</summary>


### PR DESCRIPTION
I wasn't quick enough to review #47, so let me try again.

The install page suffers from a lot of problems right now, making the whole thing unreadable and inaccessible to the average target of "new users of RGBDS".

Let's try to review the criteria:

- [x] Keep the details to the minimum. We are not interesting on explaining the intricacies of installing on Windows or in which way different ways of installing on Windows are related.
- [x] Our primary dev environment (and the largest RGBDS user quota) target is "Linux". We have pre-built binaries for amd64 on the CI (?). Until we start packaging it for main distributions, that should be the primary suggested way to obtain the binaries. End of the story.
- [x] Reading the install page is incredibly complex right now and leads to so many choices that it makes me want to give up just looking at all the branches and choices I have to make.

Feel free to discuss any of these points. In the meantime, I started an overhaul:

- Removed mention of rgbds2 package. Why would someone be interested in it? It will just make the explanation and the options more complex for new users. If I need an old version, I'll look up for an old release, no need to imply *3* choices in the Arch Linux tab. it's not an alternative/LTS branch receiving updates, so it's not like I need to subscribe to a rgbds2 package.
- Made a generic "Linux" tab as the default. Go to releases, pick a pre-built binary for the arch you need. You're done.

Fixes #51.