### PR TITLE
Replace "Contribute" with a RGBDS-live link

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -32,9 +32,9 @@ function HomepageHeader() {
           &nbsp;
           <Link
             className="button button--lg btn-learn"
-            href="https://github.com/gbdev/rgbds"
+            href="https://gbdev.io/rgbds-live/"
           >
-            Contribute
+            Try online
           </Link>
         </div>
       </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -27,7 +27,7 @@ function HomepageHeader() {
             className="button button--lg btn-contribute"
             href={`/docs/${latestStable}`}
           >
-            Read docs
+            Read manual
           </Link>
           &nbsp;
           <Link


### PR DESCRIPTION
Closes https://github.com/gbdev/rgbds-www/issues/50

We're now maintainaining RGBDS-Live, updated RGBDS to 0.6.0 and facilitated setting it up locally so contributing to you should be easier from now on. 

It replaces the "Contribute" link (which was a duplicate anyway as we already have a persistent GitHub icon in the top-right and various Contributing/Sending feedback  links around)