### PR TITLE
Add version history page

### DIFF
--- a/src/pages/docs.mdx
+++ b/src/pages/docs.mdx
@@ -25,3 +25,4 @@ Documentation is available for the following versions:
 ## Other documentation
 
 - [`.sym` file format specification](/sym)
+- [Version history](/versions)

--- a/src/pages/versions.mdx
+++ b/src/pages/versions.mdx
@@ -1,0 +1,50 @@
+---
+title: RGBDS version history
+---
+
+# RGBDS version history
+
+If you have an older project that no longer compiles using the latest RGBDS, and you do not have any recollection what version was used, this table may help you locate the correct version.
+
+| Version | Release date | Object version | Notes |
+| --- | --- | --- | --- |
+| [0.9.0-rc1](https://github.com/gbdev/rgbds/releases/tag/v0.9.0-rc1) | 2024-09-18 | v9 r11 | |
+| [0.8.0](https://github.com/gbdev/rgbds/releases/tag/v0.8.0) | 2024-06-28 | [v9 r10](https://rgbds.gbdev.io/docs/v0.8.0/rgbds.5) | |
+| [0.7.0](https://github.com/gbdev/rgbds/releases/tag/v0.7.0) | 2024-01-01 | [v9 r9](https://rgbds.gbdev.io/docs/v0.7.0/rgbds.5) | Should have been v9 r10 |
+| [0.6.1](https://github.com/gbdev/rgbds/releases/tag/v0.6.1) | 2022-12-03 | [v9 r9](https://rgbds.gbdev.io/docs/v0.6.1/rgbds.5) | |
+| [0.6.0](https://github.com/gbdev/rgbds/releases/tag/v0.6.0) | 2022-10-04 | [v9 r9](https://rgbds.gbdev.io/docs/v0.6.0/rgbds.5) | |
+| [0.6.0-rc2](https://github.com/gbdev/rgbds/releases/tag/v0.6.0-rc2) | 2022-09-09 | v9 r9 | |
+| [0.6.0-rc1](https://github.com/gbdev/rgbds/releases/tag/v0.6.0-rc1) | 2022-07-02 | v9 r9 | |
+| [0.6.0-welease-cnyandidayte](https://github.com/gbdev/rgbds/releases/tag/v0.6.0-welease-cnyandidayte) | 2022-04-01 | [v9 r9](https://rgbds.gbdev.io/docs/v0.6.0-welease-cnyandidayte/rgbds.5) | April Fools' Day |
+| [0.5.2](https://github.com/gbdev/rgbds/releases/tag/v0.5.2) | 2021-10-24 | [v9 r8](https://rgbds.gbdev.io/docs/v0.5.2/rgbds.5) | |
+| [0.5.1](https://github.com/gbdev/rgbds/releases/tag/v0.5.1) | 2021-05-09 | [v9 r8](https://rgbds.gbdev.io/docs/v0.5.1/rgbds.5) | |
+| [0.5.0](https://github.com/gbdev/rgbds/releases/tag/v0.5.0) | 2021-04-18 | [v9 r7](https://rgbds.gbdev.io/docs/v0.5.0/rgbds.5) | |
+| [0.5.0-rcCar](https://github.com/gbdev/rgbds/releases/tag/v0.5.0-rcCar) | 2021-04-01 | [v9 r7](https://rgbds.gbdev.io/docs/v0.5.0-rcCar/rgbds.5) | April Fools' Day |
+| [0.5.0-rc2](https://github.com/gbdev/rgbds/releases/tag/v0.5.0-rc2) | 2021-03-29 | v9 r7 | |
+| [0.5.0-rc1](https://github.com/gbdev/rgbds/releases/tag/v0.5.0-rc1) | 2021-03-10 | v9 r7 | |
+| [0.4.2](https://github.com/gbdev/rgbds/releases/tag/v0.4.2) | 2020-12-09 | [v9 r6](https://rgbds.gbdev.io/docs/v0.4.2/rgbds.5) | |
+| [0.4.2-pre](https://github.com/gbdev/rgbds/releases/tag/v0.4.2-pre) | 2020-10-07 | v9 r6 | |
+| [0.4.1](https://github.com/gbdev/rgbds/releases/tag/v0.4.1) | 2020-07-22 | [v9 r5](https://rgbds.gbdev.io/docs/v0.4.1/rgbds.5) | |
+| [0.4.0](https://github.com/gbdev/rgbds/releases/tag/v0.4.0) | 2020-04-03 | [v9 r3](https://rgbds.gbdev.io/docs/v0.4.0/rgbds.5) | |
+| [0.3.10](https://github.com/gbdev/rgbds/releases/tag/v0.3.10) | 2020-03-22 | [v6](https://rgbds.gbdev.io/docs/v0.3.10/rgbds.5) | |
+| [0.3.9](https://github.com/gbdev/rgbds/releases/tag/v0.3.9) | 2019-11-02 | [v6](https://rgbds.gbdev.io/docs/v0.3.9/rgbds.5) | Did not define `__RGBDS_MAJOR/MINOR/PATCH__` symbols! |
+| [0.3.8](https://github.com/gbdev/rgbds/releases/tag/v0.3.8) | 2019-02-20 | [v6](https://rgbds.gbdev.io/docs/v0.3.8/rgbds.5) | |
+| [0.3.7](https://github.com/gbdev/rgbds/releases/tag/v0.3.7) | 2018-05-03 | [v6](https://rgbds.gbdev.io/docs/v0.3.7/rgbds.5) | |
+| [0.3.6](https://github.com/gbdev/rgbds/releases/tag/v0.3.6) | 2018-03-21 | [v6](https://rgbds.gbdev.io/docs/v0.3.6/rgbds.5) | |
+| [0.3.5](https://github.com/gbdev/rgbds/releases/tag/v0.3.5) | 2018-01-28 | [v6](https://rgbds.gbdev.io/docs/v0.3.5/rgbds.5) | |
+| [0.3.4](https://github.com/gbdev/rgbds/releases/tag/v0.3.4) | 2018-01-24 | [v6](https://rgbds.gbdev.io/docs/v0.3.4/rgbds.5) | |
+| [0.3.3](https://github.com/gbdev/rgbds/releases/tag/v0.3.3) | 2017-09-16 | [v5](https://rgbds.gbdev.io/docs/v0.3.3/rgbds.5) | Started defining `__RGBDS_MAJOR/MINOR/PATCH__` symbols |
+| [0.3.2](https://github.com/gbdev/rgbds/releases/tag/v0.3.2) | 2017-07-09 | [v4](https://rgbds.gbdev.io/docs/v0.3.2/rgbds.5) | |
+| [0.3.1](https://github.com/gbdev/rgbds/releases/tag/v0.3.1) | 2017-05-02 | [v4](https://rgbds.gbdev.io/docs/v0.3.1/rgbds.5) | |
+| [0.3.0](https://github.com/gbdev/rgbds/releases/tag/v0.3.0) | 2017-04-17 | [v4](https://rgbds.gbdev.io/docs/v0.3.0/rgbds.5) | Started documenting object format |
+| [0.2.5](https://github.com/gbdev/rgbds/releases/tag/v0.2.5) | 2017-03-18 | v2 | |
+| [0.2.4](https://github.com/gbdev/rgbds/releases/tag/v0.2.4) | 2015-07-30 | v2 | |
+| [0.2.3](https://github.com/gbdev/rgbds/releases/tag/v0.2.3) | 2015-02-22 | v2 | |
+| [0.2.2](https://github.com/gbdev/rgbds/releases/tag/v0.2.2) | 2015-01-23 | v2 | |
+| [0.2.1](https://github.com/gbdev/rgbds/releases/tag/v0.2.1) | 2014-12-31 | v2 | |
+| [0.2.0](https://github.com/gbdev/rgbds/releases/tag/v0.2.0) | 2014-11-05 | v2 | |
+| [0.1.2](https://github.com/gbdev/rgbds/releases/tag/v0.1.2) | 2014-10-10 | v2 | |
+| [0.1.1](https://github.com/gbdev/rgbds/releases/tag/v0.1.1) | 2014-10-04 | v2 | |
+| [0.1.0](https://github.com/gbdev/rgbds/releases/tag/v0.1.0) | 2014-09-24 | v2 | |
+| [0.0.2](https://github.com/gbdev/rgbds/releases/tag/v0.0.2) | 2013-04-11 | v2 | |
+| [0.0.1](https://github.com/gbdev/rgbds/releases/tag/v0.0.1) | 2012-12-02 | v2 | |


### PR DESCRIPTION
Just an idea, really&mdash;have all the important info for versions at a glance.

Note: this is different from the **History** section included in the docs of recent RGBDS releases.

Now, one *could* use the GitHub releases or tags page for RGBDS to find some version that was out at the time of when a project was last modified, but it being paginated makes it a bit cumbersome to find the right version.

The object version info I imagine *could* be useful in some situations. The info comes from the [rgbds-obj crate](https://docs.rs/rgbds-obj/latest/rgbds_obj/).

Should `versions.json` have additional data to accomodate generating this table automatically?