### PR TITLE
Fix Feedback Issue Report Deadlinks

### DIFF
--- a/maintainer/support/feedback.md
+++ b/maintainer/support/feedback.md
@@ -1,7 +1,7 @@
 
 # Submitting feedback
 
-Issues should be reported on GitHub, both [issues with RGBDS itself](https://github.com/gbdev/rgbds/issues) and [issues with this site](https://github.com/gbdev/rgbds-www2/issues).
+Issues should be reported on GitHub, both [issues with RGBDS itself](https://github.com/gbdev/rgbds/issues) and [issues with this site](https://github.com/gbdev/rgbds-www/issues).
 
 Additionally, developers are very active in [the various GBDev chats](https://gbdev.io/chat).
 

--- a/versioned_docs/version-v0.9.0/feedback.md
+++ b/versioned_docs/version-v0.9.0/feedback.md
@@ -1,7 +1,7 @@
 
 # Submitting feedback
 
-Issues should be reported on GitHub, both [issues with RGBDS itself](https://github.com/gbdev/rgbds/issues) and [issues with this site](https://github.com/gbdev/rgbds-www2/issues).
+Issues should be reported on GitHub, both [issues with RGBDS itself](https://github.com/gbdev/rgbds/issues) and [issues with this site](https://github.com/gbdev/rgbds-www/issues).
 
 Additionally, developers are very active in [the various GBDev chats](https://gbdev.io/chat).
 

--- a/versioned_docs/version-v0.9.1/feedback.md
+++ b/versioned_docs/version-v0.9.1/feedback.md
@@ -1,7 +1,7 @@
 
 # Submitting feedback
 
-Issues should be reported on GitHub, both [issues with RGBDS itself](https://github.com/gbdev/rgbds/issues) and [issues with this site](https://github.com/gbdev/rgbds-www2/issues).
+Issues should be reported on GitHub, both [issues with RGBDS itself](https://github.com/gbdev/rgbds/issues) and [issues with this site](https://github.com/gbdev/rgbds-www/issues).
 
 Additionally, developers are very active in [the various GBDev chats](https://gbdev.io/chat).
 


### PR DESCRIPTION
On 3 feedback pages (such as [this](https://rgbds.gbdev.io/docs/v0.9.1/feedback) one), the "issues with this site" link is broken.