### PR TITLE
List version 0.9.2

### DIFF
--- a/src/pages/versions.mdx
+++ b/src/pages/versions.mdx
@@ -8,6 +8,7 @@ If you have an older project that no longer compiles using the latest RGBDS, and
 
 | Version | Release date | Object version | Notes |
 | --- | --- | --- | --- |
+| [0.9.2](https://github.com/gbdev/rgbds/releases/tag/v0.9.2) | 2025-05-04 | [v9 r12](https://rgbds.gbdev.io/docs/v0.9.2/rgbds.5) | |
 | [0.9.1](https://github.com/gbdev/rgbds/releases/tag/v0.9.1) | 2025-02-02 | [v9 r11](https://rgbds.gbdev.io/docs/v0.9.1/rgbds.5) | |
 | [0.9.0](https://github.com/gbdev/rgbds/releases/tag/v0.9.0) | 2024-12-25 | [v9 r11](https://rgbds.gbdev.io/docs/v0.9.0/rgbds.5) | |
 | [0.9.0-rc2](https://github.com/gbdev/rgbds/releases/tag/v0.9.0-rc2) | 2024-10-21 | v9 r11 | |


### PR DESCRIPTION
After RGBDS 0.9.2 is released, we'll need to merge this.