### PR TITLE
Omit the version number from distributed release archive filenames

### DIFF
--- a/install/linux.md
+++ b/install/linux.md
@@ -11,16 +11,15 @@ If a satisfactory version is available, it is a good idea to install from there.
 
 ## Using our pre-built binaries
 
-1. Go the [latest release](https://github.com/gbdev/rgbds/releases/latest) (or pick [a specific version](https://github.com/gbdev/rgbds/releases))
-2. Under "Assets" at the bottom, download <code>rgbds-<var>&lt;version&gt;</var>-linux-x86_64.tar.xz</code> (for example, version 0.7.0 would have `rgbds-0.7.0-linux-x86_64.tar.xz`)
-3. Extract the .tar.xz file into a new directory, and run `install.sh` as root in that directory. E.g.:
+1. Download the [latest release of `rgbds-linux-x86_64.tar.xz`](https://github.com/gbdev/rgbds/releases/download/latest/rgbds-linux-x86_64.tar.xz). (Or pick [a specific version](https://github.com/gbdev/rgbds/releases) and download it under "Assets" at the bottom.)
+2. Extract the downloaded `rgbds-linux-x86_64.tar.xz` file into a new directory, and run `install.sh` as root in that directory. For example:
    ```console
    % mkdir rgbds
-   % tar xf rgbds-0.7.0-linux-x86_64.tar.xz -C rgbds
+   % tar xf rgbds-linux-x86_64.tar.xz -C rgbds
    % cd rgbds
    % sudo ./install.sh
    ```
-4. Check that RGBDS was correctly installed by running `rgbasm -V`.
+3. Check that RGBDS was correctly installed by running `rgbasm -V`.
    It should print out the version number you installed!
 
 ---

--- a/install/macos.md
+++ b/install/macos.md
@@ -21,12 +21,12 @@ brew install rgbds --HEAD
 
 ## Using our pre-built binaries
 
-1. Go the [latest release](https://github.com/gbdev/rgbds/releases/latest) (or pick [a specific version](https://github.com/gbdev/rgbds/releases))
-2. Under "Assets" at the bottom, download <code>rgbds-<var>&lt;version&gt;</var>-macos-x86-64.zip</code> (for example, version 0.7.0 would have `rgbds-0.7.0-macos-x86-64.zip`).
-3. Extract the .zip file into a new directory, and run `install.sh` as root inside that directory.
+1. Download the [latest release of `rgbds-macos.zip`](https://github.com/gbdev/rgbds/releases/download/latest/rgbds-macos.zip). (Or pick [a specific version](https://github.com/gbdev/rgbds/releases) and download it under "Assets" at the bottom.)
+
+3. Extract the downloaded `rgbds-macos.zip` file into a new directory, and run `install.sh` as root inside that directory.
    For example, you can do that with these Console commands:
    ```console
-   % unzip -d rgbds rgbds-0.7.0-macos-x86-64.zip
+   % unzip -d rgbds rgbds-macos.zip
    % cd rgbds
    % sudo ./install.sh
    ```

--- a/install/source.md
+++ b/install/source.md
@@ -23,15 +23,14 @@ You first need to get the source files to be compiled, using one of the methods 
 <Tabs>
 <TabItem value="snapshot" label="Downloading source snapshots">
 
-1. Go the [latest release](https://github.com/gbdev/rgbds/releases/latest) (or pick [a specific version](https://github.com/gbdev/rgbds/releases))
-2. Under "Assets" at the bottom, download any of the last three listed files (<code>rgbds-<var>&lt;version&gt;</var>.tar.gz</code>, "Source code (`zip`)", or "Source code (`tar.gz`)").
-3. Extract ("unzip") the file.
+1. Download the [latest release of `rgbds-source.tar.gz`](https://github.com/gbdev/rgbds/releases/download/latest/rgbds-source.tar.gz). (Or pick [a specific version](https://github.com/gbdev/rgbds/releases) and download it under "Assets" at the bottom.) (The "Source code (`zip`)" or "Source code (`tar.gz`)" links will also work.)
+2. Extract ("unzip") the file.
 
 </TabItem>
 <TabItem value="git" label="Using Git">
 
 1. [Clone the repository](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository).
-2. Then, run `git checkout <version>` (e.g. `git checkout v0.4.1`).
+2. Then, run `git checkout <version>` (e.g. `git checkout v0.9.3`).
 3. You're set!
 
 </TabItem>

--- a/install/windows.md
+++ b/install/windows.md
@@ -21,7 +21,7 @@ You can check what your WSL distribution is by running `wsl -l -v` in the Comman
 </TabItem>
 <TabItem value="cygwin" label="Cygwin / MSYS2">
 
-1. Download the latest release of either [`rgbds-win32.zip`](https://github.com/gbdev/rgbds/releases/download/latest/rgbds-win32.zip) (for 32-bit Windows) or [`rgbds-win64.zip`](https://github.com/gbdev/rgbds/releases/download/latest/rgbds-win64.zip) (for 64-bit Windows). (Or pick [a specific version](https://github.com/gbdev/rgbds/releases) and download it under "Assets" at the bottom.)
+1. Download the latest release of either [`rgbds-win64.zip`](https://github.com/gbdev/rgbds/releases/download/latest/rgbds-win64.zip) (for 64-bit Windows) or [`rgbds-win32.zip`](https://github.com/gbdev/rgbds/releases/download/latest/rgbds-win32.zip) (for 32-bit Windows). (Or pick [a specific version](https://github.com/gbdev/rgbds/releases) and download it under "Assets" at the bottom.)
 2. Unzip the downloaded `.zip` file.
    It should give you the RGBDS `.exe` files and a couple of `.dll` files.
 3. Copy all of those `.exe` and `.dll` files to the `/usr/local/bin` directory of your Cygwin/MSYS2 installation.
@@ -48,7 +48,7 @@ If you can choose between using Cygwin or MSYS2, be advised that Cygwin is slowe
 </TabItem>
 <TabItem value="win32" label="None of those">
 
-1. Download the latest release of either [`rgbds-win32.zip`](https://github.com/gbdev/rgbds/releases/download/latest/rgbds-win32.zip) (for 32-bit Windows) or [`rgbds-win64.zip`](https://github.com/gbdev/rgbds/releases/download/latest/rgbds-win64.zip) (for 64-bit Windows). (Or pick [a specific version](https://github.com/gbdev/rgbds/releases) and download it under "Assets" at the bottom.)
+1. Download the latest release of either [`rgbds-win64.zip`](https://github.com/gbdev/rgbds/releases/download/latest/rgbds-win64.zip) (for 64-bit Windows) or [`rgbds-win32.zip`](https://github.com/gbdev/rgbds/releases/download/latest/rgbds-win32.zip) (for 32-bit Windows). (Or pick [a specific version](https://github.com/gbdev/rgbds/releases) and download it under "Assets" at the bottom.)
 2. Unzip the `.zip` file.
    It should give you the RGBDS `.exe` files and a couple of `.dll` files.
 3. Either:

--- a/install/windows.md
+++ b/install/windows.md
@@ -21,12 +21,10 @@ You can check what your WSL distribution is by running `wsl -l -v` in the Comman
 </TabItem>
 <TabItem value="cygwin" label="Cygwin / MSYS2">
 
-1. Go the [latest release](https://github.com/gbdev/rgbds/releases/latest) (or pick a specific version from [the list](https://github.com/gbdev/rgbds/releases)).
-2. Under "Assets" at the bottom, download either <code>rgbds-<var>&lt;version&gt;</var>-win32.zip</code> (for 32-bit Windows) or <code>rgbds-<var>&lt;version&gt;</var>-win64.zip</code> (for 64-bit Windows).
-   (For example, version 0.7.0 for 64-bit Windows would have `rgbds-0.7.0-win64.zip`).
-3. Unzip the .zip file.
+1. Download the latest release of either [`rgbds-win32.zip`](https://github.com/gbdev/rgbds/releases/download/latest/rgbds-win32.zip) (for 32-bit Windows) or [`rgbds-win64.zip`](https://github.com/gbdev/rgbds/releases/download/latest/rgbds-win64.zip) (for 64-bit Windows). (Or pick [a specific version](https://github.com/gbdev/rgbds/releases) and download it under "Assets" at the bottom.)
+2. Unzip the downloaded `.zip` file.
    It should give you the RGBDS `.exe` files and a couple of `.dll` files.
-4. Copy all of those `.exe` and `.dll` files to the `/usr/local/bin` directory of your Cygwin/MSYS2 installation.
+3. Copy all of those `.exe` and `.dll` files to the `/usr/local/bin` directory of your Cygwin/MSYS2 installation.
    (You can learn its equivalent Windows path by running `cygpath -w /usr/local/bin` in the Cygwin terminal.)
 
    :::caution
@@ -50,12 +48,10 @@ If you can choose between using Cygwin or MSYS2, be advised that Cygwin is slowe
 </TabItem>
 <TabItem value="win32" label="None of those">
 
-1. Go the [latest release](https://github.com/gbdev/rgbds/releases/latest) (or pick a specific version from [the list](https://github.com/gbdev/rgbds/releases))
-2. Under "Assets" at the bottom, download either <code>rgbds-<var>&lt;version&gt;</var>-win32.zip</code> (for 32-bit Windows) or <code>rgbds-<var>&lt;version&gt;</var>-win64.zip</code> (for 64-bit Windows).
-   (For example, version 0.7.0 for 64-bit Windows would have `rgbds-0.7.0-win64.zip`).
-3. Unzip the .zip file.
+1. Download the latest release of either [`rgbds-win32.zip`](https://github.com/gbdev/rgbds/releases/download/latest/rgbds-win32.zip) (for 32-bit Windows) or [`rgbds-win64.zip`](https://github.com/gbdev/rgbds/releases/download/latest/rgbds-win64.zip) (for 64-bit Windows). (Or pick [a specific version](https://github.com/gbdev/rgbds/releases) and download it under "Assets" at the bottom.)
+2. Unzip the `.zip` file.
    It should give you the RGBDS `.exe` files and a couple of `.dll` files.
-4. Either:
+3. Either:
    - ...put all of the files in a directory, then add that directory to Windows' `PATH`.
      This will *permanently* allow you to use RGBDS *from any directory*.
 


### PR DESCRIPTION
This corresponds to https://github.com/gbdev/rgbds/pull/1685. It should not be merged until the the next RGBDS release actually does this renaming.