### PR TITLE
Add workflow to build site for testing PRs

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -48,4 +48,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-        

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,23 @@
+name: Build for PR
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: Build docusaurus app
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: yarn
+      - name: Build website
+        run: |
+          yarn install --frozen-lockfile
+          yarn build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/


### PR DESCRIPTION
This will show Actions CI failure if a PR breaks the build somehow (e.g. if it wasn't tested before pushing).

If the build succeeds, it's uploaded as an artifact, which can be manually inspected, or tested by serving it (e.g. with `python -m http.server 8000`).

To do: make CI serve the build on some temporary URL?